### PR TITLE
fixes session creation based on live server data

### DIFF
--- a/crates/session/src/models/session_data.rs
+++ b/crates/session/src/models/session_data.rs
@@ -27,22 +27,28 @@ pub struct Session {
     pub circuit_code: Option<i64>, // Circuit code to use for all UDP connections
     pub session_id: Option<String>, //UUID of this session
     pub secure_session_id: Option<String>, //the secure UUID of this session
-    pub inventory_root: Option<InventoryRootValues>, // the ID of the user's root folder
+    pub inventory_root: Option<Vec<InventoryRootValues>>, // the ID of the user's root folder
     pub inventory_skeleton: Option<Vec<InventorySkeletonValues>>, // details about the child folders of the root folder.
-    pub inventory_lib_root: Option<InventoryRootValues>, // the ID of the library root folder
+    pub inventory_lib_root: Option<Vec<InventoryRootValues>>, // the ID of the library root folder
     pub inventory_skeleton_lib: Option<Vec<InventorySkeletonValues>>, //details about the child folders of the library root folder
-    pub inventory_lib_owner: Option<AgentID>, // the ID of the user that owns the library
-    pub map_server_url: Option<String>,       //URL from which to request map tiles
+    pub inventory_lib_owner: Option<Vec<AgentID>>, // the ID of the user that owns the library
+    pub map_server_url: Option<String>,            //URL from which to request map tiles
     pub buddy_list: Option<Vec<BuddyListValues>>, // the user's friend list. Contains an entry for each friend
     pub gestures: Option<Vec<GesturesValues>>,    // the gestures the user currently has active.
-    pub initial_outfit: Option<InitialOutfit>,    // use unknown, probably obsolete
-    pub global_textures: Option<GlobalTextures>,  // use unknown, probably obsolete
+    pub initial_outfit: Option<Vec<InitialOutfit>>, // use unknown, probably obsolete
+    pub global_textures: Option<Vec<GlobalTextures>>, // use unknown, probably obsolete
     pub login: Option<bool>,                      // if logged in (should be true)
-    pub login_flags: Option<LoginFlags>,
+    pub login_flags: Option<Vec<LoginFlags>>,
     pub message: Option<String>,
-    pub ui_config: Option<UiConfig>,
+    pub ui_config: Option<Vec<UiConfig>>,
     pub event_categories: Option<String>, // unknown
     pub classified_categories: Option<Vec<ClassifiedCategoriesValues>>,
+    pub real_id: Option<String>,               //TODO: NOT DOCUMENTED!!
+    pub search: Option<String>,                //TODO: NOT DOCUMENTED!!
+    pub destination_guide_url: Option<String>, //TODO: NOT DOCUMENTED!!
+    pub event_notifications: Option<String>,   //TODO: NOT DOCUMENTED!!
+    pub max_agent_groups: Option<i64>,         //TODO: NOT DOCUMENTED!!
+    pub seconds_since_epoch: Option<i64>,      //TODO: NOT DOCUMENTED!!
 }
 
 #[macro_export]
@@ -100,9 +106,10 @@ pub struct UiConfig {
 pub struct LoginFlags {
     pub stipend_since_login: String, // stipend money recieved since last login
     pub ever_logged_in: bool,        // if the account has ever logged in
-    pub seconds_since_epoch: i64,    // server time in unix seconds since epoch
-    pub daylight_savings: bool,      // whether daylight savings is in effect for grid time
-    pub gendered: bool,              // mysterious!
+    pub seconds_since_epoch: Option<i64>, // server time in unix seconds since epoch
+    // TODO: no longer sent by osgrid server
+    pub daylight_savings: bool, // whether daylight savings is in effect for grid time
+    pub gendered: bool,         // mysterious!
 }
 
 #[derive(Clone)]
@@ -184,6 +191,7 @@ pub enum InventoryType {
 ///     'position':[r<x-region-coord>,r<y-region-coord>,r<z-region-coord>],
 ///     'look_at':[r<x-coord>,r<y-coord>,r<z-coord>]} in the XML
 /// For example "{'region_handle':[r256000,r256000], 'position':[r50,r100,r200], 'look_at':[r1,r0,r0]}".
+/// sent back to the client as a string instead of a struct for some reason :(
 #[derive(Clone)]
 pub struct HomeValues {
     pub region_handle: (String, String),
@@ -226,21 +234,15 @@ fn parse_inventory_type(inventory_type: &xmlrpc::Value) -> InventoryType {
     }
 }
 
-fn string_2tuple(values: xmlrpc::Value) -> (String, String) {
-    values.as_array().unwrap();
-    (
-        values[0].as_str().unwrap().to_string(),
-        values[1].as_str().unwrap().to_string(),
-    )
-}
-
-fn string_3tuple(values: xmlrpc::Value) -> (String, String, String) {
-    values.as_array().unwrap();
-    (
-        values[0].as_str().unwrap().to_string(),
-        values[1].as_str().unwrap().to_string(),
-        values[2].as_str().unwrap().to_string(),
-    )
+fn string_3tuple(values: xmlrpc::Value) -> Option<(String, String, String)> {
+    match values.as_array() {
+        None => None,
+        Some(x) => Some((
+            x[0].as_str().unwrap().to_string(),
+            x[1].as_str().unwrap().to_string(),
+            x[2].as_str().unwrap().to_string(),
+        )),
+    }
 }
 
 fn generate_friends_rights(rights: i32) -> FriendsRights {
@@ -308,6 +310,34 @@ fn parse_inventory_skeleton(
     return Some(value_vec);
 }
 
+fn parse_inventory_root(values: Option<&xmlrpc::Value>) -> Option<Vec<InventoryRootValues>> {
+    let mut value_vec = vec![];
+    let unwrapped_values = match values {
+        None => return None,
+        Some(x) => x.as_array().unwrap(),
+    };
+    for value in unwrapped_values {
+        value_vec.push(InventoryRootValues {
+            folder_id: value["folder_id"].as_str().unwrap().to_string(),
+        });
+    }
+    return Some(value_vec);
+}
+
+fn parse_inventory_lib_owner(values: Option<&xmlrpc::Value>) -> Option<Vec<AgentID>> {
+    let mut value_vec = vec![];
+    let unwrapped_values = match values {
+        None => return None,
+        Some(x) => x.as_array().unwrap(),
+    };
+    for value in unwrapped_values {
+        value_vec.push(AgentID {
+            agent_id: value["agent_id"].as_str().unwrap().to_string(),
+        });
+    }
+    return Some(value_vec);
+}
+
 fn parse_gestures(values: Option<&xmlrpc::Value>) -> Option<Vec<GesturesValues>> {
     let mut value_vec = vec![];
     let unwrapped_values = match values {
@@ -340,84 +370,130 @@ fn parse_classified_categories(
     return Some(value_vec);
 }
 
+fn parse_initial_outfit(values: Option<&xmlrpc::Value>) -> Option<Vec<InitialOutfit>> {
+    let mut value_vec = vec![];
+    let unwrapped_values = match values {
+        None => return None,
+        Some(x) => x.as_array().unwrap(),
+    };
+    for value in unwrapped_values {
+        value_vec.push(InitialOutfit {
+            folder_name: value["folder_name"].as_str().unwrap().to_string(),
+            gender: value["gender"].as_str().unwrap().to_string(),
+        });
+    }
+    return Some(value_vec);
+}
+
+fn parse_global_textures(values: Option<&xmlrpc::Value>) -> Option<Vec<GlobalTextures>> {
+    let mut value_vec = vec![];
+    let unwrapped_values = match values {
+        None => return None,
+        Some(x) => x.as_array().unwrap(),
+    };
+    for value in unwrapped_values {
+        value_vec.push(GlobalTextures {
+            cloud_texture_id: value["cloud_texture_id"].as_str().unwrap().to_string(),
+            sun_texture_id: value["sun_texture_id"].as_str().unwrap().to_string(),
+            moon_texture_id: value["moon_texture_id"].as_str().unwrap().to_string(),
+        });
+    }
+    return Some(value_vec);
+}
+
+fn parse_login_flags(values: Option<&xmlrpc::Value>) -> Option<Vec<LoginFlags>> {
+    let mut value_vec = vec![];
+    let unwrapped_values = match values {
+        None => return None,
+        Some(x) => x.as_array().unwrap(),
+    };
+    for value in unwrapped_values {
+        value_vec.push(LoginFlags {
+            stipend_since_login: value["stipend_since_login"].as_str().unwrap().to_string(),
+            ever_logged_in: match value["ever_logged_in"].as_str().unwrap() {
+                "Y" => true,
+                "N" => false,
+                _ => false,
+            },
+            seconds_since_epoch: value["seconds_since_epoch"].as_i64(),
+            daylight_savings: match value["daylight_savings"].as_str().unwrap() {
+                "Y" => true,
+                "N" => false,
+                _ => false,
+            },
+            gendered: match value["gendered"].as_str().unwrap() {
+                "Y" => true,
+                "N" => false,
+                _ => false,
+            },
+        });
+    }
+    return Some(value_vec);
+}
+
+fn parse_ui_config(values: Option<&xmlrpc::Value>) -> Option<Vec<UiConfig>> {
+    let mut value_vec = vec![];
+    let unwrapped_values = match values {
+        None => return None,
+        Some(x) => x.as_array().unwrap(),
+    };
+    for value in unwrapped_values {
+        value_vec.push(UiConfig {
+            allow_first_life: match value["allow_first_life"].as_str().unwrap() {
+                "Y" => true,
+                "N" => false,
+                _ => false,
+            },
+        });
+    }
+    return Some(value_vec);
+}
+
+// this is literally the worst thing I've ever been forced to do
+// why this is the singular field that is passed as a string is beyond me
+// this is so cursed and I hate it
 impl Into<HomeValues> for xmlrpc::Value {
     fn into(self) -> HomeValues {
-        HomeValues {
-            region_handle: string_2tuple(self["region_handle"].clone()),
-            look_at: string_3tuple(self["look_at"].clone()),
-            position: string_3tuple(self["position"].clone()),
-        }
-    }
-}
+        let mut home_values_object: HomeValues = HomeValues {
+            region_handle: ("".to_string(), "".to_string()),
+            look_at: ("".to_string(), "".to_string(), "".to_string()),
+            position: ("".to_string(), "".to_string(), "".to_string()),
+        };
 
-impl Into<InventoryRootValues> for xmlrpc::Value {
-    fn into(self) -> InventoryRootValues {
-        InventoryRootValues {
-            folder_id: self["folder_id"].as_str().unwrap().to_string(),
-        }
-    }
-}
+        let valuestring = self.as_str().unwrap().to_string();
+        let split: Vec<&str> = valuestring.split("],").collect();
+        for element in split {
+            let splitvalue: Vec<&str> = element.split(":[").collect();
+            let label = splitvalue[0]
+                .replace("{'", "")
+                .replace("'", "")
+                .replace(" ", "");
+            let values = splitvalue[1].replace("]}", "");
+            let values: Vec<&str> = values.split(",").collect();
 
-impl Into<AgentID> for xmlrpc::Value {
-    fn into(self) -> AgentID {
-        AgentID {
-            agent_id: self["agent_id"].as_str().unwrap().to_string(),
+            match label.as_str() {
+                "region_handle" => {
+                    home_values_object.region_handle =
+                        (values[0].to_string(), values[1].to_string())
+                }
+                "look_at" => {
+                    home_values_object.look_at = (
+                        values[0].to_string(),
+                        values[1].to_string(),
+                        values[2].to_string(),
+                    )
+                }
+                "position" => {
+                    home_values_object.position = (
+                        values[0].to_string(),
+                        values[1].to_string(),
+                        values[2].to_string(),
+                    )
+                }
+                _ => continue,
+            }
         }
-    }
-}
-
-impl Into<InitialOutfit> for xmlrpc::Value {
-    fn into(self) -> InitialOutfit {
-        InitialOutfit {
-            folder_name: self["folder_name"].as_str().unwrap().to_string(),
-            gender: self["gender"].as_str().unwrap().to_string(),
-        }
-    }
-}
-
-impl Into<GlobalTextures> for xmlrpc::Value {
-    fn into(self) -> GlobalTextures {
-        GlobalTextures {
-            cloud_texture_id: self["cloud_texture_id"].as_str().unwrap().to_string(),
-            sun_texture_id: self["sun_texture_id"].as_str().unwrap().to_string(),
-            moon_texture_id: self["moon_texture_id"].as_str().unwrap().to_string(),
-        }
-    }
-}
-
-impl Into<LoginFlags> for xmlrpc::Value {
-    fn into(self) -> LoginFlags {
-        LoginFlags {
-            stipend_since_login: self["stipend_since_login"].as_str().unwrap().to_string(),
-            ever_logged_in: match self["ever_logged_in"].as_str().unwrap() {
-                "Y" => true,
-                "N" => false,
-                _ => false,
-            },
-            seconds_since_epoch: self["seconds_since_epoch"].as_i64().unwrap(),
-            daylight_savings: match self["daylight_savings"].as_str().unwrap() {
-                "Y" => true,
-                "N" => false,
-                _ => false,
-            },
-            gendered: match self["gendered"].as_str().unwrap() {
-                "Y" => true,
-                "N" => false,
-                _ => false,
-            },
-        }
-    }
-}
-
-impl Into<UiConfig> for xmlrpc::Value {
-    fn into(self) -> UiConfig {
-        UiConfig {
-            allow_first_life: match self["allow_first_life"].as_str().unwrap() {
-                "Y" => true,
-                "N" => false,
-                _ => false,
-            },
-        }
+        return home_values_object;
     }
 }
 
@@ -425,7 +501,7 @@ impl Into<Session> for xmlrpc::Value {
     fn into(self) -> Session {
         Session {
             home: Some(self["home"].clone().into()),
-            look_at: Some(string_3tuple(self["look_at"].clone())),
+            look_at: string_3tuple(self["look_at"].clone()),
             agent_access: parse_agent_access(self.get("agent_access")),
             agent_access_max: parse_agent_access(self.get("agent_access_max")),
             seed_capability: str_val!(self["seed_capability"]),
@@ -443,20 +519,20 @@ impl Into<Session> for xmlrpc::Value {
             circuit_code: i64_val!(self["circuit_code"]),
             session_id: str_val!(self["session_id"]),
             secure_session_id: str_val!(self["secure_session_id"]),
-            inventory_root: Some(self["inventory-root"].clone().into()),
+            inventory_root: parse_inventory_root(self.get("inventory-root")),
             inventory_skeleton: parse_inventory_skeleton(self.get("inventory-skeleton")),
-            inventory_lib_root: Some(self["inventory-lib-root"].clone().into()),
+            inventory_lib_root: parse_inventory_root(self.get("inventory-lib-root")),
             inventory_skeleton_lib: parse_inventory_skeleton(self.get("inventory-skel-lib")),
-            inventory_lib_owner: Some(self["inventory-lib-owner"].clone().into()),
+            inventory_lib_owner: parse_inventory_lib_owner(self.get("inventory-lib-owner")),
             map_server_url: str_val!(self["map-server-url"]),
             buddy_list: parse_buddy_list(self.get("buddy-list")),
             gestures: parse_gestures(self.get("gestures")),
-            initial_outfit: Some(self["initial-outfit"].clone().into()),
-            global_textures: Some(self["global-textures"].clone().into()),
+            initial_outfit: parse_initial_outfit(self.get("initial-outfit")),
+            global_textures: parse_global_textures(self.get("global-textures")),
             login: bool_val!(self["login"]),
-            login_flags: Some(self["login-flags"].clone().into()),
+            login_flags: parse_login_flags(self.get("login-flags")),
             message: str_val!(self["message"]),
-            ui_config: Some(self["ui-config"].clone().into()),
+            ui_config: parse_ui_config(self.get("ui-config")),
             event_categories: str_val!(self["event_categories"]),
             classified_categories: parse_classified_categories(self.get("classified_categories")),
             ..Session::default()

--- a/crates/session/tests/session.rs
+++ b/crates/session/tests/session.rs
@@ -82,7 +82,7 @@ fn test_mock_session() {
         Some("fe210274-9056-467a-aff7-d95f60bacccc".to_string())
     );
     assert_eq!(
-        session.inventory_root.unwrap().folder_id,
+        session.inventory_root.unwrap()[0].folder_id,
         "37c4cfe3-ea39-4ef7-bda3-bee73bd46d95".to_string()
     );
     let inv_skel = session.inventory_skeleton.unwrap();
@@ -92,7 +92,7 @@ fn test_mock_session() {
         "004d663b-9980-46ae-8559-bb60e9d67d28".to_string()
     );
     assert_eq!(
-        session.inventory_lib_root.unwrap().folder_id,
+        session.inventory_lib_root.unwrap()[0].folder_id,
         "37c4cfe3-ea39-4ef7-bda3-bee73bd46d95".to_string()
     );
     let inv_skel_lib = session.inventory_skeleton_lib.unwrap();
@@ -102,7 +102,7 @@ fn test_mock_session() {
         "004d663b-9980-46ae-8559-bb60e9d67d28".to_string()
     );
     assert_eq!(
-        session.inventory_lib_owner.unwrap().agent_id,
+        session.inventory_lib_owner.unwrap()[0].agent_id,
         "11111111-1111-0000-0000-000100bba000".to_string()
     );
     assert_eq!(
@@ -129,17 +129,20 @@ fn test_mock_session() {
         "004d663b-9980-46ae-8559-bb60e9d67d28".to_string()
     );
     assert_eq!(
-        session.initial_outfit.unwrap().folder_name,
+        session.initial_outfit.unwrap()[0].folder_name,
         "Nightclub Female".to_string()
     );
     assert_eq!(
-        session.global_textures.unwrap().sun_texture_id,
+        session.global_textures.unwrap()[0].sun_texture_id,
         "cce0f112-878f-4586-a2e2-a8f104bba271".to_string()
     );
     assert_eq!(session.login.unwrap(), true);
-    assert_eq!(session.login_flags.unwrap().seconds_since_epoch, 1411075065);
+    assert_eq!(
+        session.login_flags.unwrap()[0].seconds_since_epoch,
+        Some(1411075065)
+    );
     assert_eq!(session.message.unwrap(), "Welcome, Avatar!".to_string());
-    assert_eq!(session.ui_config.unwrap().allow_first_life, true);
+    assert_eq!(session.ui_config.unwrap()[0].allow_first_life, true);
     assert_eq!(
         session.classified_categories.unwrap()[0].category_name,
         "Shopping".to_string()
@@ -193,7 +196,8 @@ fn test_lib_auth() {
     );
     let verify = panic::catch_unwind(|| {
         let session = new_session(login_response).unwrap();
-        assert_eq!(session.agent_access, Some(AgentAccess::Mature));
+
+        assert_eq!(session.login.unwrap(), true);
     });
     if verify.is_err() {
         assert_eq!(

--- a/crates/session/tests/test_server/login_models.py
+++ b/crates/session/tests/test_server/login_models.py
@@ -123,11 +123,7 @@ class homeParams(object):
         self.z_coord=           "r" + z_coord 
 
     def asdict(self): 
-        return{
-                "region_handle" :[self.x_grid_coord, self.y_grid_coord],
-                "position"      :[self.x_region_coord, self.y_region_coord, self.z_region_coord],
-                "look_at"       :[self.x_coord, self.y_coord, self.z_coord]
-                }
+        return "{'region_handle' :[" + self.x_grid_coord + "," + self.y_grid_coord + "], 'position':[" + self.x_region_coord + "," + self.y_region_coord + "," + self.z_region_coord + "], 'look_at' :[" + self.x_coord + "," + self.y_coord+ "," +  self.z_coord + "]}"
 
 class lookAtParams(object): 
     def __init__(self, 
@@ -202,20 +198,20 @@ class loginResponse(object):
             circuit_code            =697482820,
             session_id              ="6ac2e761-f490-4122-bf6c-7ad8fbb17002",
             secure_session_id       ="fe210274-9056-467a-aff7-d95f60bacccc",
-            inventory_root          =inventoryRootParams().asdict(),
+            inventory_root          =[inventoryRootParams().asdict()],
             inventory_skeleton      =[inventorySkeletonParams().asdict(), inventorySkeletonParams().asdict()],
-            inventory_lib_root      =inventoryRootParams().asdict(),
+            inventory_lib_root      =[inventoryRootParams().asdict()],
             inventory_skel_lib      =[inventorySkeletonParams().asdict(), inventorySkeletonParams().asdict()], 
-            inventory_lib_owner     =inventoryLibOwner().asdict(), 
+            inventory_lib_owner     =[inventoryLibOwner().asdict()], 
             map_server_url          ="http://192.168.1.2:8002/", 
             buddy_list              =[buddy().asdict(), buddy().asdict(), buddy().asdict()],
             gestures                =[gesture().asdict(), gesture().asdict()],
-            initial_outfit          =initialOutfit().asdict(),
-            global_textures         =globalTexturesParams().asdict(),
+            initial_outfit          =[initialOutfit().asdict()],
+            global_textures         =[globalTexturesParams().asdict()],
             login                   ="true", 
-            login_flags             =loginFlagsParams().asdict(),
+            login_flags             =[loginFlagsParams().asdict()],
             message                 ="Welcome, Avatar!",
-            ui_config               =uiConfigParams().asdict(),
+            ui_config               =[uiConfigParams().asdict()],
             event_categories        =[],
             classified_categories   =[classifiedCategory().asdict(), classifiedCategory().asdict()]
             ):


### PR DESCRIPTION
session can now be created from live osgrid data! Mock server sends a response almost identical to the data sent from osgrid, as defined on the SimulatorLoginProtocol wiki page, using defaults defined there
TODO: 
 - document and enable the odd, undocumented fields
 - create tests for malformed login responses 
 - create tests for other grids