### PR TITLE
login fixes, testing against other grids

### DIFF
--- a/crates/login/Cargo.toml
+++ b/crates/login/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metaverse_login"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Skyler Clark<skylerjaneclark@gmail.com>"]
 description = "login utility for accessing the metaverse"
 edition = "2018"
@@ -14,4 +14,4 @@ lazy_static = "1.4.0"
 config = "0.11"
 sys-info = "0.9.1"
 mac_address = "1.1.2"
-
+md-5 = "0.9.1"

--- a/crates/login/tests/login.rs
+++ b/crates/login/tests/login.rs
@@ -329,6 +329,7 @@ fn read_creds() -> Option<HashMap<String, String>> {
 }
 
 fn validate_grid_response(login_response: xmlrpc::Value, firstname: String, lastname: String) {
+    println!("{:?}", login_response);
     let verify = panic::catch_unwind(|| {
         assert_eq!(login_response["login"], xmlrpc::Value::from("true"));
         assert_eq!(login_response["first_name"], xmlrpc::Value::from(firstname));

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 
 [dependencies]
 config = "0.11"
-metaverse_login = "0.0.1"
+metaverse_login = "0.0.2"
 xmlrpc = "0.15.1"


### PR DESCRIPTION
adds md5 hashing for password and viewer digest. 
I really don't think that the password should be hashed with md5 anymore that's a really bad idea but the spec says so 
testing against metropolis to see what other grids send back in their login repsonses. May add a few other grids to be sure the session is working properly.